### PR TITLE
Implements arch type functions & refactors out "_settings" global variable.

### DIFF
--- a/source/com/dub.d
+++ b/source/com/dub.d
@@ -50,11 +50,11 @@ import dub.internal.vibecompat.core.log;
 	upgrade();
 
 	_compilerBinaryName = _dub.defaultCompiler;
-	_compiler = getCompiler(_compilerBinaryName);
+	Compiler compiler = getCompiler(_compilerBinaryName);
 	BuildSettings settings;
-	_platform = _compiler.determinePlatform(settings, _compilerBinaryName);
+	auto platform = compiler.determinePlatform(settings, _compilerBinaryName);
 
-	_configuration = _dub.project.getDefaultConfiguration(_platform);
+	_configuration = _dub.project.getDefaultConfiguration(platform);
 	assert(_dub.project.configurations.canFind(_configuration), "No configuration available");
 	updateImportPaths(false);
 }
@@ -217,7 +217,7 @@ string[] archTypes() @property
 {
 	string[] types = [ "x86_64", "x86" ];
 
-	if(_compiler.name == "gdc")
+	if(getCompiler(_compilerBinaryName).name == "gdc")
 	{
 		types ~= [ "arm", "arm_thumb" ];
 	}
@@ -296,7 +296,7 @@ bool setCompiler(string compiler)
 	try
 	{
 		_compilerBinaryName = compiler;
-		_compiler = getCompiler(compiler);
+		Compiler comp = getCompiler(compiler); // make sure it gets a valid compiler
 		return true;
 	}
 	catch (Exception e)
@@ -413,8 +413,6 @@ __gshared
 	string _buildType = "debug";
 	string _cwdStr;
 	string _compilerBinaryName;
-	Compiler _compiler;
-	BuildPlatform _platform;
 	string[] _importPaths, _stringImportPaths;
 }
 

--- a/source/com/dub.d
+++ b/source/com/dub.d
@@ -210,12 +210,19 @@ bool setConfiguration(string configuration)
 	return updateImportPaths(false);
 }
 
-/// List all possible arch types, even one's not possible for every compiler (eg ARM for dmd).
+/// List all possible arch types for current set compiler
 /// Call_With: `{"subcmd": "list:arch-types"}`
 @arguments("subcmd", "list:arch-types")
 string[] archTypes() @property
 {
-	return [ "x86", "x86_64" ]; // todo update this list to include all other archs
+	string[] types = [ "x86_64", "x86" ];
+
+	if(_compiler.name == "gdc")
+	{
+		types ~= [ "arm", "arm_thumb" ];
+	}
+
+	return types;
 }
 
 /// Returns the current selected arch type

--- a/source/com/dub.d
+++ b/source/com/dub.d
@@ -49,10 +49,10 @@ import dub.internal.vibecompat.core.log;
 	start();
 	upgrade();
 
-	string compilerName = _dub.defaultCompiler;
-	_compiler = getCompiler(compilerName);
+	_compilerBinaryName = _dub.defaultCompiler;
+	_compiler = getCompiler(_compilerBinaryName);
 	BuildSettings settings;
-	_platform = _compiler.determinePlatform(settings, compilerName);
+	_platform = _compiler.determinePlatform(settings, _compilerBinaryName);
 
 	_configuration = _dub.project.getDefaultConfiguration(_platform);
 	assert(_dub.project.configurations.canFind(_configuration), "No configuration available");
@@ -104,9 +104,9 @@ bool updateImportPaths(bool restartDub = true)
 	if (restartDub)
 		restart();
 
-	auto compiler = getCompiler(.compiler);
+	auto compiler = getCompiler(_compilerBinaryName);
 	BuildSettings buildSettings;
-	auto buildPlatform = compiler.determinePlatform(buildSettings, .compiler, _archType);
+	auto buildPlatform = compiler.determinePlatform(buildSettings, _compilerBinaryName, _archType);
 
 	GeneratorSettings settings;
 	settings.platform = buildPlatform;
@@ -284,7 +284,7 @@ bool setBuildType(JSONValue request)
 @arguments("subcmd", "get:compiler")
 string compiler() @property
 {
-	return _compiler.name;
+	return _compilerBinaryName;
 }
 
 /// Selects a new compiler for building
@@ -295,6 +295,7 @@ bool setCompiler(string compiler)
 {
 	try
 	{
+		_compilerBinaryName = compiler;
 		_compiler = getCompiler(compiler);
 		return true;
 	}
@@ -329,10 +330,9 @@ auto path() @property
 	new Thread({
 		try
 		{
-			string compilerName = .compiler;
-			auto compiler = getCompiler(compilerName);
+			auto compiler = getCompiler(_compilerBinaryName);
 			BuildSettings buildSettings;
-			auto buildPlatform = compiler.determinePlatform(buildSettings, compilerName, _archType);
+			auto buildPlatform = compiler.determinePlatform(buildSettings, _compilerBinaryName, _archType);
 
 			GeneratorSettings settings;
 			settings.platform = buildPlatform;
@@ -412,6 +412,7 @@ __gshared
 	string _archType = "x86_64";
 	string _buildType = "debug";
 	string _cwdStr;
+	string _compilerBinaryName;
 	Compiler _compiler;
 	BuildPlatform _platform;
 	string[] _importPaths, _stringImportPaths;


### PR DESCRIPTION
Also requires the code-d commit to match. There was a global _settings variable that was being passed around. From the looks of it, it was possible to simply keep adding and adding flags to it without it ever clearing itself anywhere. The dub function "determinePlatform" that takes it in to add flags never clears it either. So I simply removed it as it didn't seem to be needed anyways.
