### PR TITLE
Workaround for spawnProcess not working on OSX

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -11,7 +11,17 @@ import std.exception;
 import std.bitmanip;
 import std.process;
 import std.traits;
-import std.stdio;
+version (OSX) {
+	import std.stdio : stdout, stderr, File;
+	static import std.stdio;
+	File stdin;
+	static this() {
+		stdin = std.stdio.stdin;
+		std.stdio.stdin = File("/dev/null", "r");
+	}
+} else {
+	import std.stdio;
+}
 import std.json;
 import std.meta;
 import std.conv;


### PR DESCRIPTION
On OSX, there is a bug that if the stdin is busy being read, then the
std.process.execute function will be blocked until the read is
fulfilled. This happen because both the reading and the subprocess
spawning will issue a flock on the stdin file.
This workaround will replace the global stdin with a File pointing to
/dev/null while maintaning a reference to the original stdin in the
app.d scope.

Related to:
https://github.com/Pure-D/code-d/issues/29