### PR TITLE
Update Dependencies - dfmt:0.7.0, dscanner:0.5.2, inifiled:1.3.1, dsymbol:0.3.0-beta3, emsi_containers:0.7.0, libdparse:0.8.0-alpha.5

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,9 +12,9 @@
 		"painlessjson": "~>1.3.8",
 		"libdparse": "*",
 		"standardpaths": "~>0.8.0",
-		"dfmt": "0.5.3",
-		"dscanner": "~>0.4.2",
-		"inifiled": "~>1.0.2"
+		"dfmt": "0.7.0",
+		"dscanner": "~>0.5.2",
+		"inifiled": "~>1.3.1"
 	},
 	"subPackages": [
 		"./installer",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,20 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dfmt": "0.7.0",
+		"dscanner": "0.5.2",
+		"dsymbol": "0.3.0-beta.3",
+		"dub": "1.8.1",
+		"dunit": "1.0.14",
+		"emsi_containers": "0.7.0",
+		"inifiled": "1.3.1",
+		"isfreedesktop": "0.1.1",
+		"libddoc": "0.2.0",
+		"libdparse": "0.8.0-alpha.5",
+		"painlessjson": "1.3.8",
+		"painlesstraits": "0.2.0",
+		"standardpaths": "0.8.0",
+		"stdx-allocator": "2.77.0",
+		"xdgpaths": "0.2.4"
+	}
+}

--- a/source/workspaced/com/dcdext.d
+++ b/source/workspaced/com/dcdext.d
@@ -175,13 +175,14 @@ final class InterfaceMethodFinder : ASTVisitor
 			if (baseClassList)
 				foreach (base; baseClassList.items)
 				{
-					if (!base.type2 || !base.type2.symbol || !base.type2.symbol.identifierOrTemplateChain
-							|| !base.type2.symbol.identifierOrTemplateChain.identifiersOrTemplateInstances.length)
+					//@Reviewer: type2.symbol was removed as of libdparse fix #158, replaced by typeIdentifierChain
+					//           TypeIdentifierChain was renamed to TypeIdentifierPart as of commit 0964cee3e6e
+					if (!base.type2 || !base.type2.typeIdentifierPart || !base.type2.typeIdentifierPart.identifierOrTemplateInstance)
 						continue;
 					details.parents ~= astToString(base.type2);
 					details.parentPositions ~= cast(
-							int) base.type2.symbol.identifierOrTemplateChain
-						.identifiersOrTemplateInstances[0].identifier.index + 1;
+							int) base.type2.typeIdentifierPart.identifierOrTemplateInstance
+						.identifier.index + 1;
 				}
 			inTarget = true;
 			details.needsOverride = needsOverride;

--- a/source/workspaced/com/dscanner.d
+++ b/source/workspaced/com/dscanner.d
@@ -10,10 +10,11 @@ import std.typecons;
 import core.sync.mutex;
 import core.thread;
 
-import analysis.base;
-import analysis.config;
-import analysis.run;
-import symbol_finder;
+//@Reviewer: D-Scanner src got moved under the package "dscanner" as of v0.5.2.
+import dscanner.analysis.base;
+import dscanner.analysis.config;
+import dscanner.analysis.run;
+import dscanner.symbol_finder;
 
 import inifiled : INI, readINIFile;
 
@@ -188,9 +189,9 @@ private const(Module) parseModule(string file, ubyte[] code, RollbackAllocator* 
 	new Thread({
 		try
 		{
-			static import readers;
+			static import dscanner.utils;
 
-			string[] paths = readers.expandArgs([""] ~ importPathProvider());
+			string[] paths = dscanner.utils.expandArgs([""] ~ importPathProvider());
 			foreach_reverse (i, path; paths)
 				if (path == "stdin")
 					paths = paths.remove(i);
@@ -532,8 +533,9 @@ final class DefinitionFinder : ASTVisitor
 	override void visit(const AliasDeclaration dec)
 	{
 		// Old style alias
-		if (dec.identifierList)
-			foreach (i; dec.identifierList.identifiers)
+		//@Reviewer: AliasDeclaration.identifierList was renamed to declaratorIdentifierList in fix #158 of libdparse
+		if (dec.declaratorIdentifierList)
+			foreach (i; dec.declaratorIdentifierList.identifiers)
 				definitions ~= makeDefinition(i.text, i.line, "a", context);
 		dec.accept(this);
 	}


### PR DESCRIPTION
workspace-d can almost build on windows out of the box using the command 
dub build --build=debug --arch=x86_mscoff

Updating the dependencies dfmt and dscanner gets past the build issues recorded in Issue #87. The updated dependencies requiredupdating some API in workspaced/com, so I made this merge request in order to record those changes.

I haven't thoroughly tested the compiled binary, so I wouldn't recommend taking this pull request verbatim. But I thought it would be useful to share the changes as notes for doing actual dependency updating.

Bumped dfmt to version 0.7.0
Bumped dscanner to version 0.5.2
Bumped inifiled to version 1.3.1
Selections set dsymbol to v0.3.0-beta.3
Selections set emsi_containers to v0.7.0
Selections set libdparse to v0.8.0-alpha.5
Updated dcdext.d to support libdparse v0.8.0-alpha.1
Updated dscanner.d to support dscanner v0.5.2

Note: There's currently a bug on building D-Scanner for windows. See https://github.com/dlang-community/D-Scanner/pull/621
It's also possible to apply the fix for this issue manually by modifying D-Scanner's dub.json. See https://github.com/dlang-community/D-Scanner/commit/e322923a10df78d6c4da6bc7f81041e4aabd4298 .