### PR TITLE
Find declaration returns declaration of character in front of cursor Fixes Pure-D/code-d#237

### DIFF
--- a/source/workspaced/com/dcd.d
+++ b/source/workspaced/com/dcd.d
@@ -335,7 +335,8 @@ class DCDComponent : ComponentWrapper
 					ret.finish(DCDDeclaration.init);
 					return;
 				}
-				auto pipes = doClient(["-c", pos.to!string, "--symbolLocation"]);
+				// Declarations should be returned for character *in front of* the cursor.
+				auto pipes = doClient(["-c", (pos+1).to!string, "--symbolLocation"]);
 				scope (exit)
 				{
 					pipes.pid.wait();


### PR DESCRIPTION
By default, DCD will return declarations and autocompletes for the character just behind the cursor. This is expected behaviour for autocomplete however it is normal that when looking up declarations, you look up the symbol in front of the cursor. This (5 character) changes the lookup to be on the character ahead.

```
int foo(Bar bar) {
     ^ Old lookup requires cursor to be here
    ^ New lookup allows cursor to be here
```