### PR TITLE
Fix some memory leak issues

### DIFF
--- a/source/workspaced/com/dcdext.d
+++ b/source/workspaced/com/dcdext.d
@@ -350,6 +350,7 @@ class DCDExtComponent : ComponentWrapper
 	/// See_Also: CodeBlockInfo
 	CodeBlockInfo getCodeBlockRange(scope const(char)[] code, int position)
 	{
+		RollbackAllocator rba;
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto parsed = parseModule(tokens, "getCodeBlockRange_input.d", &rba);
 		auto reader = new CodeBlockInfoFinder(position);
@@ -367,6 +368,7 @@ class DCDExtComponent : ComponentWrapper
 
 		scope const(char)[] codeBlock = code[container.innerRange[0] .. container.innerRange[1]];
 
+		RollbackAllocator rba;
 		scope tokensInsert = getTokensForParser(cast(ubyte[]) insert, config,
 				&workspaced.stringCache);
 		scope parsedInsert = parseModule(tokensInsert, "insertCode_insert.d", &rba);
@@ -790,6 +792,7 @@ class DCDExtComponent : ComponentWrapper
 	/// Extracts information about a given class or interface at the given position.
 	InterfaceDetails getInterfaceDetails(string file, scope const(char)[] code, int position)
 	{
+		RollbackAllocator rba;
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto parsed = parseModule(tokens, file, &rba);
 		auto reader = new InterfaceMethodFinder(code, position);
@@ -843,7 +846,6 @@ class DCDExtComponent : ComponentWrapper
 	}
 
 private:
-	RollbackAllocator rba;
 	LexerConfig config;
 }
 

--- a/source/workspaced/com/importer.d
+++ b/source/workspaced/com/importer.d
@@ -31,6 +31,7 @@ class ImporterComponent : ComponentWrapper
 	/// Returns all imports available at some code position.
 	ImportInfo[] get(scope const(char)[] code, int pos)
 	{
+		RollbackAllocator rba;
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto mod = parseModule(tokens, "code", &rba);
 		auto reader = new ImporterReaderVisitor(pos);
@@ -43,6 +44,7 @@ class ImporterComponent : ComponentWrapper
 	ImportModification add(string importName, scope const(char)[] code, int pos,
 			bool insertOutermost = true)
 	{
+		RollbackAllocator rba;
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto mod = parseModule(tokens, "code", &rba);
 		auto reader = new ImporterReaderVisitor(pos);
@@ -173,6 +175,7 @@ class ImporterComponent : ComponentWrapper
 
 		part = code[start .. end];
 
+		RollbackAllocator rba;
 		auto tokens = getTokensForParser(cast(ubyte[]) part, config, &workspaced.stringCache);
 		auto mod = parseModule(tokens, "code", &rba);
 		auto reader = new ImporterReaderVisitor(-1);
@@ -198,7 +201,6 @@ class ImporterComponent : ComponentWrapper
 	}
 
 private:
-	RollbackAllocator rba;
 	LexerConfig config;
 }
 

--- a/source/workspaced/com/moduleman.d
+++ b/source/workspaced/com/moduleman.d
@@ -34,6 +34,7 @@ class ModulemanComponent : ComponentWrapper
 		if (!refInstance)
 			throw new Exception("moduleman.rename requires to be instanced");
 
+		RollbackAllocator rba;
 		FileChanges[] changes;
 		bool foundModule = false;
 		auto from = mod.split('.');
@@ -170,7 +171,6 @@ class ModulemanComponent : ComponentWrapper
 	}
 
 private:
-	RollbackAllocator rba;
 	LexerConfig config;
 }
 

--- a/source/workspaced/com/snippets/package.d
+++ b/source/workspaced/com/snippets/package.d
@@ -48,7 +48,7 @@ class SnippetsComponent : ComponentWrapper
 		providers ~= dependencySnippets;
 	}
 
-	/** 
+	/**
 	 * Params:
 	 *   file = Filename to resolve dependencies relatively from.
 	 *   code = Code to complete snippet in.
@@ -95,6 +95,7 @@ class SnippetsComponent : ComponentWrapper
 			}
 		}
 
+		RollbackAllocator rba;
 		scope parsed = parseModule(tokens, cast(string) file, &rba);
 
 		trace("determineSnippetInfo at ", position);
@@ -435,7 +436,6 @@ private:
 		return tuple(info, futures.data);
 	}
 
-	RollbackAllocator rba;
 	LexerConfig config;
 }
 


### PR DESCRIPTION
Rollback allocators leak. I moved them into the scopes they are used in. I tried to set checkpoint + rollback on scope exit, but got segfault. Bringing them in scope is *maybe* slower (without a benchmark it's nonsensial to say), but at least it is safe.

Futures leak too. They need to join threads explicitly.