### PR TITLE
Reuse rollback allocators between calls in some places

### DIFF
--- a/source/workspaced/com/dcdext.d
+++ b/source/workspaced/com/dcdext.d
@@ -350,7 +350,8 @@ class DCDExtComponent : ComponentWrapper
 	/// See_Also: CodeBlockInfo
 	CodeBlockInfo getCodeBlockRange(scope const(char)[] code, int position)
 	{
-		RollbackAllocator rba;
+		const rollbackPoint = rba.setCheckpoint();
+		scope (exit) rba.rollback(rollbackPoint);
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto parsed = parseModule(tokens, "getCodeBlockRange_input.d", &rba);
 		auto reader = new CodeBlockInfoFinder(position);
@@ -368,7 +369,8 @@ class DCDExtComponent : ComponentWrapper
 
 		scope const(char)[] codeBlock = code[container.innerRange[0] .. container.innerRange[1]];
 
-		RollbackAllocator rba;
+		const rollbackPoint = rba.setCheckpoint();
+		scope (exit) rba.rollback(rollbackPoint);
 		scope tokensInsert = getTokensForParser(cast(ubyte[]) insert, config,
 				&workspaced.stringCache);
 		scope parsedInsert = parseModule(tokensInsert, "insertCode_insert.d", &rba);
@@ -792,7 +794,8 @@ class DCDExtComponent : ComponentWrapper
 	/// Extracts information about a given class or interface at the given position.
 	InterfaceDetails getInterfaceDetails(string file, scope const(char)[] code, int position)
 	{
-		RollbackAllocator rba;
+		const rollbackPoint = rba.setCheckpoint();
+		scope (exit) rba.rollback(rollbackPoint);
 		auto tokens = getTokensForParser(cast(ubyte[]) code, config, &workspaced.stringCache);
 		auto parsed = parseModule(tokens, file, &rba);
 		auto reader = new InterfaceMethodFinder(code, position);
@@ -846,6 +849,7 @@ class DCDExtComponent : ComponentWrapper
 	}
 
 private:
+	RollbackAllocator rba;
 	LexerConfig config;
 }
 

--- a/source/workspaced/com/snippets/package.d
+++ b/source/workspaced/com/snippets/package.d
@@ -95,7 +95,8 @@ class SnippetsComponent : ComponentWrapper
 			}
 		}
 
-		RollbackAllocator rba;
+		const rollbackPoint = rba.setCheckpoint();
+		scope (exit) rba.rollback(rollbackPoint);
 		scope parsed = parseModule(tokens, cast(string) file, &rba);
 
 		trace("determineSnippetInfo at ", position);
@@ -436,6 +437,7 @@ private:
 		return tuple(info, futures.data);
 	}
 
+	RollbackAllocator rba;
 	LexerConfig config;
 }
 


### PR DESCRIPTION
Explodes with the current libdparse dependency.