### PR TITLE
Fix serve-d being stuck in endless loop after closing vscode

### DIFF
--- a/source/workspaced/api.d
+++ b/source/workspaced/api.d
@@ -106,7 +106,10 @@ mixin template DefaultComponentWrapper(bool withDtor = true)
 			if (!_threads)
 				synchronized (this)
 					if (!_threads)
+					{
 						_threads = new TaskPool(max(minSize, min(maxSize, defaultPoolThreads)));
+						_threads.isDaemon = true;
+					}
 			return _threads;
 		}
 

--- a/source/workspaced/backend.d
+++ b/source/workspaced/backend.d
@@ -623,7 +623,10 @@ class WorkspaceD
 		if (!_gthreads)
 			synchronized (this)
 				if (!_gthreads)
+				{
 					_gthreads = new TaskPool(max(2, min(6, defaultPoolThreads)));
+					_gthreads.isDaemon = true;
+				}
 		return _gthreads;
 	}
 }

--- a/source/workspaced/com/dcd.d
+++ b/source/workspaced/com/dcd.d
@@ -249,7 +249,7 @@ class DCDComponent : ComponentWrapper
 						}
 					}
 				}
-				catch (Throable t)
+				catch (Throwable t)
 				{
 					running = false;
 				}


### PR DESCRIPTION
That should be enough to fix: 

- https://github.com/Pure-D/serve-d/issues/185
- https://github.com/Pure-D/serve-d/issues/186

Although in my testing dcd-server stayed alive, but at 0% cpu usage, so.. i'm not sure where to check right now

I also edited this PR from the github website, code style might get altered, sorry about that!

